### PR TITLE
feat: allow mkd command to create directories recursively

### DIFF
--- a/src/commands/registration/mkd.js
+++ b/src/commands/registration/mkd.js
@@ -7,7 +7,7 @@ module.exports = {
     if (!this.fs) return this.reply(550, 'File system not instantiated');
     if (!this.fs.mkdir) return this.reply(402, 'Not supported by file system');
 
-    return Promise.try(() => this.fs.mkdir(command.arg))
+    return Promise.try(() => this.fs.mkdir(command.arg, { recursive: true }))
     .then((dir) => {
       const path = dir ? `"${escapePath(dir)}"` : undefined;
       return this.reply(257, path);

--- a/src/fs.js
+++ b/src/fs.js
@@ -119,7 +119,7 @@ class FileSystem {
 
   mkdir(path) {
     const {fsPath} = this._resolvePath(path);
-    return fsAsync.mkdir(fsPath)
+    return fsAsync.mkdir(fsPath, { recursive: true })
     .then(() => fsPath);
   }
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -338,6 +338,18 @@ describe('Integration', function () {
       });
     });
 
+    it('MKD témp multiple levels deep', (done) => {
+      const path = `${clientDirectory}/${name}/témp/first/second`;
+      if (fs.existsSync(path)) {
+        fs.rmdirSync(path);
+      }
+      client.mkdir('témp/first/second', (err) => {
+        expect(err).to.not.exist;
+        expect(fs.existsSync(path)).to.equal(true);
+        done();
+      });
+    });
+
     it('CWD témp', (done) => {
       client.cwd('témp', (err, data) => {
         expect(err).to.not.exist;


### PR DESCRIPTION
The MKD command should be making all the necessary directories when uploading to a directory that doesn't exists yet. 
Previously this wasn't the case, by adding ```{ recursive: true }``` to the ```fs.mkdir``` function this should work correctly now.

NodeJS version 10.12.0 has added a native support for both mkdir and mkdirSync to create a directory recursively with [recursive: true](https://nodejs.org/api/fs.html#fs_fs_mkdirsync_path_options)