### PR TITLE
New event emitters (connect, server-error, closing, closed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,44 @@ Disable write actions such as upload, delete, etc.
 
 The `FtpSrv` class extends the [node net.Server](https://nodejs.org/api/net.html#net_class_net_server). Some custom events can be resolved or rejected, such as `login`.
 
+### `client-error`
+```js
+ftpServer.on('client-error', ({connection, context, error}) => { ... });
+```
+
+Occurs when an error arises in the client connection.
+
+`connection` [client class object](src/connection.js)  
+`context` string of where the error occurred  
+`error` error object
+
+### `disconnect`
+```js
+ftpServer.on('disconnect', ({connection, id, newConnectionCount}) => { ... });
+```
+
+Occurs when a client has disconnected.
+
+`connection` [client class object](src/connection.js)  
+`id` string of the disconnected connection id  
+`id` number of the new connection count (exclusive the disconnected client connection)
+
+### `closed`
+```js
+ftpServer.on('closed', ({}) => { ... });
+```
+
+Occurs when the FTP server has been closed.
+
+### `closing`
+```js
+ftpServer.on('closing', ({error}) => { ... });
+```
+
+Occurs when the FTP server is closing.
+
+`error` if successful, will be `null` 
+
 ### `login`
 ```js
 ftpServer.on('login', ({connection, username, password}, resolve, reject) => { ... });
@@ -252,15 +290,13 @@ Occurs when a client is attempting to login. Here you can resolve the login requ
 
 `reject` takes an error object
 
-### `client-error`
+### `server-error`
 ```js
-ftpServer.on('client-error', ({connection, context, error}) => { ... });
+ftpServer.on('server-error', ({error}) => { ... });
 ```
 
-Occurs when an error arises in the client connection.
-
-`connection` [client class object](src/connection.js)  
-`context` string of where the error occurred  
+Occurs when an error arises in the FTP server.
+ 
 `error` error object
 
 ### `RETR`

--- a/README.md
+++ b/README.md
@@ -256,12 +256,10 @@ Occurs when the FTP server has been closed.
 
 ### `closing`
 ```js
-ftpServer.on('closing', ({error}) => { ... });
+ftpServer.on('closing', ({}) => { ... });
 ```
 
-Occurs when the FTP server is closing.
-
-`error` if successful, will be `null` 
+Occurs when the FTP server has started closing.
 
 ### `login`
 ```js

--- a/src/index.js
+++ b/src/index.js
@@ -50,8 +50,7 @@ class FtpServer extends EventEmitter {
 
       socket.on('close', () => this.disconnectClient(connection.id));
       socket.once('close', () => {
-        let newConnectionCount = Object.keys(this.connections).length;
-        this.emit('disconnect', {connection, id: connection.id, newConnectionCount: newConnectionCount});
+        this.emit('disconnect', {connection, id: connection.id, newConnectionCount: Object.keys(this.connections).length});
       })
       
       this.emit('connect', {connection, id: connection.id, newConnectionCount: Object.keys(this.connections).length});

--- a/src/index.js
+++ b/src/index.js
@@ -54,8 +54,7 @@ class FtpServer extends EventEmitter {
         this.emit('disconnect', {connection, id: connection.id, newConnectionCount: newConnectionCount});
       })
       
-      let newConnectionCount = Object.keys(this.connections).length;
-      this.emit('connect', {connection, id: connection.id, newConnectionCount: newConnectionCount});
+      this.emit('connect', {connection, id: connection.id, newConnectionCount: Object.keys(this.connections).length});
 
       const greeting = this._greeting || [];
       const features = this._features || 'Ready';

--- a/src/index.js
+++ b/src/index.js
@@ -152,6 +152,7 @@ class FtpServer extends EventEmitter {
 
   close() {
     this.server.maxConnections = 0;
+    this.emit('closing');
     this.log.info('Closing connections:', Object.keys(this.connections).length);
 
     return Promise.all(Object.keys(this.connections).map((id) => this.disconnectClient(id)))
@@ -159,7 +160,6 @@ class FtpServer extends EventEmitter {
       this.server.close((err) => {
         this.log.info('Server closing...');
         if (err) this.log.error(err, 'Error closing server');
-        this.emit('closing', {error: err});
         resolve('Closed');
       });
     }))


### PR DESCRIPTION
Dear,

Based on my [discussion ](https://github.com/QuorumDMS/ftp-srv/discussions/310) I would like to contribute the following event emitter changes:

+ The existing `disconnect` event has now 1 extra parameter parameter *"newConnectionCount"*, to make it easier to know how much connections are still active (after the disconnect).

+ A new `connect` event has been added, identical to the existing disconnect event.

+ A new `server-error` event has been added, to intercept server-side errors (like e.g. unparsable IP address).

+ A new `closing` event has been added, to know when the server is closing.

+ A new `closed` event has been added, to know when the server has been closed.

Documentation has been added to the readme page for all these new events, and also for the existing `disconnect` event.

Hopefully you like these changes.  Looking forward for a new version including these events, because it could offer a lot of potential for our Node-RED community.

Don't hesitate to let me know if something is not clear or if I need to change something!

Thanks for reviewing!!
Bart