### PR TITLE
Allow multiple options in the LIST command

### DIFF
--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -3,7 +3,7 @@ const Promise = require('bluebird');
 
 const REGISTRY = require('./registry');
 
-const CMD_FLAG_REGEX = new RegExp(/^-(\w{1})$/);
+const CMD_FLAG_REGEX = new RegExp(/^-(\w{1,5})$/);
 
 class FtpCommands {
   constructor(connection) {

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -3,7 +3,7 @@ const Promise = require('bluebird');
 
 const REGISTRY = require('./registry');
 
-const CMD_FLAG_REGEX = new RegExp(/^-(\w{1,5})$/);
+const CMD_FLAG_REGEX = new RegExp(/^(--?\w+)$/);
 
 class FtpCommands {
   constructor(connection) {


### PR DESCRIPTION
Laravel (using the League FTP package) sends at least 3 options in a LIST command (see https://github.com/thephpleague/flysystem/blob/3.x/src/Ftp/FtpAdapter.php#L367). This fixes the command not returning the files or directories in the directory.

I'm not aware of any implications; it simply works for me.