### PR TITLE
feat: make _resolvePath available in types

### DIFF
--- a/ftp-srv.d.ts
+++ b/ftp-srv.d.ts
@@ -21,6 +21,11 @@ export class FileSystem {
 
     chdir(path?: string): Promise<string>;
 
+    protected _resolvePath(path?: string): {
+      clientPath: string,
+      fsPath: string
+    };
+
     write(fileName: string, {append, start}?: {
         append?: boolean;
         start?: any;


### PR DESCRIPTION
The PR adds `_resolvePath` as protected in the typings so when extending the `Filesystem` class can be used

### Acceptance Checklist

- [ ] **Story**: Code is focused on the linked stories and solves a problem
- One of:
  - [ ] **For Bugs**: A unit test is added or an existing one modified
  - [ ] **For Features**: New unit tests are added covering the new functions or modifications
- [x ] Code Documentation changes are included for public interfaces and important / complex additions
- [ ] External Documentation is included for API changes, or other external facing interfaces

### Review Checklist

- [ ] The code does not duplicate existing functionality that exists elsewhere
- [ ] The code has been linted and follows team practices and style guidelines
- [ ] The changes in the PR are relevant to the title
  - changes not related should be moved to a different PR
- [ ] All errors or error handling is actionable, and informs the viewer on how to correct it
