### PR TITLE
chore: get tests running with node24

### DIFF
--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -105,7 +105,7 @@ describe('Integration', function () {
       else fs.unlinkSync(item);
     });
 
-    fs.rmdirSync(dir, { recursive: true });
+    fs.rmSync(dir, { recursive: true });
   }
 
   function runFileSystemTests(name) {
@@ -336,7 +336,7 @@ describe('Integration', function () {
     it('MKD témp', (done) => {
       const path = `${clientDirectory}/${name}/témp`;
       if (fs.existsSync(path)) {
-        fs.rmdirSync(path);
+        fs.rmSync(path);
       }
       client.mkdir('témp', (err) => {
         expect(err).to.not.exist;
@@ -348,14 +348,14 @@ describe('Integration', function () {
     it('MKD témp multiple levels deep', (done) => {
       const path = `${clientDirectory}/${name}/témp`;
       if (fs.existsSync(path)) {
-        fs.rmdirSync(path, {recursive: true});
+        fs.rmSync(path, {recursive: true});
       }
 
       client.mkdir('témp/first/second', (err) => {
         expect(err).to.not.exist;
         expect(fs.existsSync(path)).to.equal(true);
 
-        fs.rmdirSync(path, {recursive: true});
+        fs.rmSync(path, {recursive: true});
         done();
       });
     });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -481,7 +481,7 @@ describe('Integration', function () {
       ]))
       .then(([key, cert, ca]) => startServer({
         url: 'ftp://127.0.0.1:8881',
-        tls: {key, cert, ca}
+        tls: {key, cert, ca, ciphers: "DEFAULT:@SECLEVEL=0",}
       }))
       .then(() => {
         return connectClient({


### PR DESCRIPTION
node24 does not accept certificates which are expired, bypass the reject by the added option


### Acceptance Checklist

- [ ] **Story**: Code is focused on the linked stories and solves a problem
- One of:
  - [ ] **For Bugs**: A unit test is added or an existing one modified
  - [ ] **For Features**: New unit tests are added covering the new functions or modifications
- [ ] Code Documentation changes are included for public interfaces and important / complex additions
- [ ] External Documentation is included for API changes, or other external facing interfaces

### Review Checklist

- [ ] The code does not duplicate existing functionality that exists elsewhere
- [ ] The code has been linted and follows team practices and style guidelines
- [ ] The changes in the PR are relevant to the title
  - changes not related should be moved to a different PR
- [ ] All errors or error handling is actionable, and informs the viewer on how to correct it


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test cleanup procedures for improved compatibility.

* **Chores**
  * Enhanced TLS configuration for explicit and implicit server contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->